### PR TITLE
Fix cce api update

### DIFF
--- a/utils.go
+++ b/utils.go
@@ -593,6 +593,7 @@ func getNodeRequirement(state state, count int64) *common.NodeInfo {
 		Kind:       "Node",
 		APIVersion: "v3",
 		MetaData: common.NodeMetaInfo{
+			Name:   state.DisplayName,
 			Labels: state.NodeConfig.NodeLabels,
 		},
 		Spec: common.NodeSpecInfo{


### PR DESCRIPTION
As Huawei public cloud api is changed, we need to add node name parameter for cce node creation API request.